### PR TITLE
Update AzureQueueStorageSink.cs

### DIFF
--- a/src/Serilog.Sinks.AzureQueueStorage/Sinks/AzureQueueStorage/AzureQueueStorageSink.cs
+++ b/src/Serilog.Sinks.AzureQueueStorage/Sinks/AzureQueueStorage/AzureQueueStorageSink.cs
@@ -80,11 +80,15 @@ namespace Serilog.Sinks.AzureQueueStorage
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
+            TextWriter writer = new StringWriter();
+            _textFormatter.Format(logEvent,writer);
+            var output = writer.ToString();
+
             var queue = _cloudQueueProvider.GetCloudQueue(_storageAccount, _storageQueueName, _bypassQueueCreationValidation);
 
             CloudQueueClient queueClient = _storageAccount.CreateCloudQueueClient();
             CloudQueue storageQueueName = queueClient.GetQueueReference(_storageQueueName);
-            CloudQueueMessage message = new CloudQueueMessage(JsonConvert.SerializeObject(logEvent));
+            CloudQueueMessage message = new CloudQueueMessage(output);
 
             queue.AddMessageAsync(message)
                 .SyncContextSafeWait(_waitTimeoutMilliseconds);


### PR DESCRIPTION
Emit uses supplied textformatter.

Instead of just serializing the event object, AzureQueueStorageSink should use the ITextformatter supplied in the constructor